### PR TITLE
0.2.3.12: `print.indirect_list()` can print each path individually.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: manymome
 Title: Mediation, Moderation and Moderated-Mediation After Model Fitting
-Version: 0.2.3.11
+Version: 0.2.3.12
 Authors@R:
     c(person(given = "Shu Fai",
            family = "Cheung",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# manymome 0.2.3.11
+# manymome 0.2.3.12
 
 ## New Features
 
@@ -44,6 +44,13 @@
   and confidence interval computed from
   original standard error when
   appropriate. (0.2.3.10)
+
+- Added `for_each_path` argument to the
+  `print`-method of `indirect_list`
+  objects. Setting it to `TRUE` to print
+  each path in the output of
+  `many_indirect_effects()` individually.
+  (0.2.3.12)
 
 ## Documentation and Notes
 

--- a/R/print_indirect_list.R
+++ b/R/print_indirect_list.R
@@ -60,7 +60,19 @@
 #' values, depending on the method used
 #' to form the confidence intervals.
 #'
-#' @param ... Other arguments. Not used.
+#' @param for_each_path Logical. If
+#' `TRUE`, each of the paths will be
+#' printed individually, using the
+#' `print`-method of the output of
+#' [indirect_effect()]. Default is
+#' `FALSE`.
+#'
+#' @param ... Other arguments. If
+#' `for_each_path` is `TRUE`, they
+#' will be passed to the print method
+#' of the output of [indirect_effect()].
+#' Ignored otherwise.
+#'
 #'
 #'
 #' @references
@@ -101,7 +113,23 @@ print.indirect_list <- function(x, digits = 3,
                                 pvalue = FALSE,
                                 pvalue_digits = 3,
                                 se = FALSE,
+                                for_each_path = FALSE,
                                 ...) {
+    if (for_each_path) {
+        section_sep <- paste0(rep("-",
+                              round(getOption("width") * .80)),
+                              collapse = "")
+        for (xx in x) {
+            cat(section_sep, "\n")
+            print(xx,
+                  digits = digits,
+                  pvalue = pvalue,
+                  pvalue_digits = pvalue_digits,
+                  se = se,
+                  ...)
+          }
+        return(invisible(x))
+      }
     xold <- x
     my_call <- attr(x, "call")
     x_paths <- attr(x, "paths")

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![R-CMD-check](https://github.com/sfcheung/manymome/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/sfcheung/manymome/actions/workflows/R-CMD-check.yaml)
 <!-- badges: end -->
 
-(Version 0.2.3.11, updated on 2024-09-29, [release history](https://sfcheung.github.io/manymome/news/index.html))
+(Version 0.2.3.12, updated on 2024-09-29, [release history](https://sfcheung.github.io/manymome/news/index.html))
 
 # manymome  <img src="man/figures/logo.png" align="right" height="150" />
 

--- a/man/print.indirect_list.Rd
+++ b/man/print.indirect_list.Rd
@@ -12,6 +12,7 @@ Object}
   pvalue = FALSE,
   pvalue_digits = 3,
   se = FALSE,
+  for_each_path = FALSE,
   ...
 )
 }
@@ -45,7 +46,18 @@ estimates or Monte Carlo simulated
 values, depending on the method used
 to form the confidence intervals.}
 
-\item{...}{Other arguments. Not used.}
+\item{for_each_path}{Logical. If
+\code{TRUE}, each of the paths will be
+printed individually, using the
+\code{print}-method of the output of
+\code{\link[=indirect_effect]{indirect_effect()}}. Default is
+\code{FALSE}.}
+
+\item{...}{Other arguments. If
+\code{for_each_path} is \code{TRUE}, they
+will be passed to the print method
+of the output of \code{\link[=indirect_effect]{indirect_effect()}}.
+Ignored otherwise.}
 }
 \value{
 \code{x} is returned invisibly.

--- a/tests/testthat/test_all_indirect_paths.R
+++ b/tests/testthat/test_all_indirect_paths.R
@@ -150,28 +150,33 @@ out_tmp <- outa4[c(1, 3, 5, 6)]
 ind_1_no_ci <- many_indirect_effects(out_tmp,
                                fit = fit)
 ind_1_no_ci
+print(ind_1_no_ci, digits = 4, for_each_path = TRUE)
 
 ind_1_no_ci_stdx <- many_indirect_effects(out_tmp,
                                fit = fit,
                                standardized_x = TRUE)
 ind_1_no_ci_stdx
+print(ind_1_no_ci_stdx, digits = 4, for_each_path = TRUE)
 
 ind_1_no_ci_stdy <- many_indirect_effects(out_tmp,
                                fit = fit,
                                standardized_y = TRUE)
 ind_1_no_ci_stdy
+print(ind_1_no_ci_stdy, digits = 4, for_each_path = TRUE)
 
 ind_1_no_ci_std <- many_indirect_effects(out_tmp,
                                fit = fit,
                                standardized_x = TRUE,
                                standardized_y = TRUE)
 ind_1_no_ci_std
+print(ind_1_no_ci_std, digits = 4, for_each_path = TRUE)
 
 ind_1 <- many_indirect_effects(out_tmp,
                                fit = fit,
                                boot_ci = TRUE,
                                boot_out = fit_boot_out)
 ind_1
+print(ind_1, digits = 4, pvalue = TRUE, for_each_path = TRUE)
 
 ind_1_stdx <- many_indirect_effects(out_tmp,
                                fit = fit,


### PR DESCRIPTION
Tests, checks, and build_site() passed.