### PR TITLE
0.2.9.7: Fixed the error of `do_mc()` for some mg models with latent variables

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: manymome
 Title: Mediation, Moderation and Moderated-Mediation After Model Fitting
-Version: 0.2.9.6
+Version: 0.2.9.7
 Authors@R:
     c(person(given = "Shu Fai",
            family = "Cheung",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# manymome 0.2.9.6
+# manymome 0.2.9.7
 
 ## New Features
 
@@ -26,6 +26,14 @@
 
 - Improve the printout of a list of
   indirect effects. (0.2.9.1, 0.2.9.2)
+
+## Bug Fixes
+
+- Fixed the error raised when `do_mc()`
+  is used for some multigroup models with
+  latent variables. No impact on results
+  because latent means are not
+  used for now. (0.2.9.7)
 
 # manymome 0.2.9
 

--- a/R/lavaan_helpers.R
+++ b/R/lavaan_helpers.R
@@ -45,21 +45,40 @@ lav_implied_all_lavaan <- function(fit,
       lvnames <- lavaan::lavNames(fit, "lv")
     }
     allnames <- c(ovnames, lvnames)
+    ngroups <- lavaan::lavTech(fit, "ngroups")
     if (lavaan::lavInspect(fit, "meanstructure")) {
         if (length(lvnames) > 0) {
+            implied_ov <- lavaan::lavInspect(fit, "mean.ov")
+            implied_lv <- lavaan::lavInspect(fit, "mean.lv")
+            if (ngroups > 1) {
+              implied_means <- mapply(c,
+                                      implied_ov,
+                                      implied_lv,
+                                      SIMPLIFY = FALSE)
+            } else {
+              implied_means <- c(implied_ov, implied_lv)
+            }
             out <- list(cov = lavaan::lavInspect(fit, "cov.all"),
-                        mean = c(lavaan::lavInspect(fit, "mean.ov"),
-                                  lavaan::lavInspect(fit, "mean.lv")))
+                        mean = implied_means,
+                        mean_lv = implied_lv)
           } else {
             out <- list(cov = lavaan::lavInspect(fit, "cov.all"),
-                        mean = c(lavaan::lavInspect(fit, "mean.ov")))
+                        mean = unclass(lavaan::lavInspect(fit, "mean.ov")))
           }
       } else {
+        if (ngroups > 1) {
+          tmp <- replicate(ngroups,
+                          stats::setNames(rep(NA, length(allnames)),
+                                            allnames),
+                          simplify = FALSE)
+          names(tmp) <- lavaan::lavTech(fit, "group.label")
+        } else {
+          tmp <- stats::setNames(rep(NA, length(allnames)),
+                                            allnames)
+        }
         out <- list(cov = lavaan::lavInspect(fit, "cov.all"),
-                    mean = stats::setNames(rep(NA, length(allnames)),
-                                           allnames))
+                    mean = tmp)
       }
-    out
   }
 
 #' @noRd

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![R-CMD-check](https://github.com/sfcheung/manymome/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/sfcheung/manymome/actions/workflows/R-CMD-check.yaml)
 <!-- badges: end -->
 
-(Version 0.2.9.6, updated on 2025-07-12, [release history](https://sfcheung.github.io/manymome/news/index.html))
+(Version 0.2.9.7, updated on 2025-07-20, [release history](https://sfcheung.github.io/manymome/news/index.html))
 
 # manymome  <img src="man/figures/logo.png" align="right" height="150" />
 


### PR DESCRIPTION
Tests, checks, and build_site() passed.