### PR TITLE
`many_indirect_effects()` will reuse `ci_out` if `ci_type` is used.

### DIFF
--- a/R/cond_indirect.R
+++ b/R/cond_indirect.R
@@ -1531,7 +1531,8 @@ many_indirect_effects <- function(paths, ...) {
     xym <- all_paths_to_df(paths)
     args <- list(...)
     if ((isTRUE(args$boot_ci) && is.null(args$boot_out)) ||
-        (isTRUE(args$mc_ci) && is.null(args$mc_out))) {
+        (isTRUE(args$mc_ci) && is.null(args$mc_out)) ||
+        (!is.null(args$ci_type) && is.null(args$ci_out))) {
         do_sim_once <- TRUE
       } else {
         do_sim_once <- FALSE
@@ -1552,6 +1553,10 @@ many_indirect_effects <- function(paths, ...) {
                 args_final <- utils::modifyList(args,
                               list(mc_out = sim_out))
               }
+            if (!is.null(args$ci_type)) {
+                args_final <- utils::modifyList(args,
+                              list(ci_out = sim_out))
+            }
           } else {
             args_final <- args
           }
@@ -1577,6 +1582,10 @@ many_indirect_effects <- function(paths, ...) {
                 args_final <- utils::modifyList(args,
                               list(mc_out = sim_out))
               }
+            if (!is.null(args$ci_type)) {
+                args_final <- utils::modifyList(args,
+                              list(ci_out = sim_out))
+            }
           } else {
             args_final <- args
           }

--- a/tests/testthat/test_all_indirect_paths.R
+++ b/tests/testthat/test_all_indirect_paths.R
@@ -261,3 +261,16 @@ test_that("Check total indirect effect", {
     expect_identical(tot1_no_ci_m11, ind_1_no_ci[[1]])
     expect_error(total_indirect_effect(ind_1_stdx, x = "x2", y = "y1"))
   })
+
+# Test reusing boot_out
+
+ind_1_reuse <- many_indirect_effects(out_tmp,
+                                     fit = fit_tmp,
+                                     R = 50,
+                                     ci_type = "boot",
+                                     seed = 98743,
+                                     ncores = 2)
+expect_equal(
+  as.character(ind_1_reuse[[2]]$cond_indirect_call$ci_out),
+  "ci_out"
+)


### PR DESCRIPTION
tests and checks passed.